### PR TITLE
fix DISQUS post URL

### DIFF
--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -9,7 +9,7 @@
         var disqus_shortname = '{{ site.disqus_shortname }}';
         var disqus_identifier = '{{ page.id }}';
         var disqus_title = '{{ page.title }}';
-        var disqus_url = '{{ site.url }}{{ post.url }}';
+        var disqus_url = '{{ site.url }}{{ page.url }}';
         /*var disqus_developer = 1;*/
 
         (function() {


### PR DESCRIPTION
Hi there!

Your Jekyll theme is awesome. I am using it for my personal blog and my company blog.

I have write comment to a post with DISQUS. But something weird is happen, the same comment is shown at all of another post. You can look at here:

1. http://update.viugraph.com/2017/09/viugraph-versi-0-1-10-upload-lancar/
1. http://update.viugraph.com/2017/08/viugraph-versi-0-1-9-share/
1. http://update.viugraph.com/2017/08/viugraph-versi-0-1-7/

When I try to debug the blog at my laptop with this command:
`bundle exec jekyll serve`

the code from `_includes/comments.html`:

```javascript
var disqus_shortname = '{{ site.disqus_shortname }}';
var disqus_identifier = '{{ page.id }}';
var disqus_title = '{{ page.title }}';
var disqus_url = '{{ site.url }}{{ page.url }}'; // <=== this is the culprit
```

will rendered on each post as:
```javascript
var disqus_url = 'http://update.viugraph.com'; // <=== this is the culprit
```

It make my comment will shown at all of posts. When I change the code to:
```javascript
var disqus_url = '{{ site.url }}{{ post.url }}';
```

it will display comments correctly (only show comments for a post). 